### PR TITLE
Stack IE11 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     {
       "name": "Tomas Nyvlt",
       "email": "nnyvlt@gmail.com"
+    },
+    {
+      "name": "Martin Skara",
+      "email": "jsem@skaramart.in"
     }
   ],
   "scripts": {

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -34,8 +34,9 @@ const Stack: FC<StackProps> = ({
   ) =>
     direction.reduce((acc, val, i) => ({
       mb: [...acc.mb, val === 'column' ? s[i] : 0],
-      mr: [...acc.mr, val === 'row' ? s[i] : 0]
-    }), { mb: [], mr: [] } as { mb: (string | number | null)[]; mr: (string | number | null)[] });
+      mr: [...acc.mr, val === 'row' ? s[i] : 0],
+      maxWidth: [...acc.maxWidth, val === 'column' ? '100%': 'none']
+    }), { mb: [], mr: [], maxWidth: [] } as { mb: (string | number | null)[]; mr: (string | number | null)[]; maxWidth: (string | number | null)[] });
 
   return (
     <Flex


### PR DESCRIPTION
Elements in Stack with column direction must have maxWidth="100%". 

Without this, specifically text in Stack child elements is not wrapping. 

